### PR TITLE
Upgrade setup-samV2 usando instalador

### DIFF
--- a/{{cookiecutter.nombre_repo}}/.github/workflows/reusable_deploy.yml
+++ b/{{cookiecutter.nombre_repo}}/.github/workflows/reusable_deploy.yml
@@ -108,6 +108,7 @@ jobs:
 
       - uses: aws-actions/setup-sam@v2
         with:
+          version: 1.37.0
           use-installer: true
 
       # Se obtienen propiedades del proyecto

--- a/{{cookiecutter.nombre_repo}}/.github/workflows/reusable_deploy.yml
+++ b/{{cookiecutter.nombre_repo}}/.github/workflows/reusable_deploy.yml
@@ -106,9 +106,9 @@ jobs:
         with:
           python-version: '3.8'
 
-      - uses: aws-actions/setup-sam@v1
+      - uses: aws-actions/setup-sam@v2
         with:
-          version: 1.37.0
+          use-installer: true
 
       # Se obtienen propiedades del proyecto
       - name: "Cargando pfg-sam.json y parameters-{env}.json"


### PR DESCRIPTION
Se actualiza la version de sam de V1 a V2 usando el instalador

Description:
Actualmente, se utiliza una versión vieja de SAM. Posiblemente vaya a fallar.
De igual modo, si se actualiza y adicional se utiliza el instalador al momento de ejecutarse la acción puede reducir un tiempo de ejcución del workflow de al rededor de 20 segundos.

Issue: [Upgrade setup-sam a V2 usando instalador - issue #16](https://devops-sps.atlassian.net/browse/ROAD-111)

Se anexa evidencia de actualización de versión y reduccion de tiempo de 20 segundos:

![image](https://github.com/spsmexico/aws_sam_github_quickstart_template/assets/127790618/c690c535-b025-47cd-8752-45ec0af26763)
