### PR TITLE
Limpieza de respaldos

### DIFF
--- a/{{cookiecutter.nombre_repo}}/dynamo.py
+++ b/{{cookiecutter.nombre_repo}}/dynamo.py
@@ -352,7 +352,7 @@ def funcion_madre(nombre_tabla):
                 if backup_despliegue.startswith('despliegue_'):
                     # Se obtiene el ARN del respaldo
                     backup_despliegue_arn = lista_respaldos[numero_backup]["BackupArn"]
-                    # Se contabilizan los respaldos hehcos por despliegues.
+                    # Se contabilizan los respaldos hechos por despliegues.
                     numero_backup_despliegues = numero_backup_despliegues + 1
 
                     # Agrega todos los respaldos hechos por despliegues a una lista.


### PR DESCRIPTION
Se agregan las funciones 'limpieza_respaldos()' y 'lista_respaldos_paginados()' para realizar la limpieza de respaldo en las tablas de dynamo.

Issue: [Limpieza de respaldos - issue #15](https://devops-sps.atlassian.net/browse/ROAD-112)

Se agregaron las siguientes funciones:

```
lista_respaldos_paginados(nombre_tabla)

limpieza_respaldos(nombre_tabla, lista_respaldos)
```

Se ejecutó el workflow **push_manual_main** y se observa que se realiza la limpieza de respaldos:

![image](https://github.com/spsmexico/aws_sam_github_quickstart_template/assets/127790618/7fde763a-9df7-4cdb-830e-1f842d51b816)